### PR TITLE
Fixes for first person animations + Support for Combat overhaul

### DIFF
--- a/starvation/modinfo.json
+++ b/starvation/modinfo.json
@@ -6,7 +6,7 @@
         "trollusk"
     ],
     "description": "Realistic replacement for the Vanilla hunger system, based on human physiology.",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "dependencies": {
         "game": "1.20.3"
     }

--- a/starvation/src/ModSystemStarvation.cs
+++ b/starvation/src/ModSystemStarvation.cs
@@ -16,6 +16,8 @@ using Vintagestory.API.Util;
 using Vintagestory.ServerMods.WorldEdit;
 using Vintagestory.Client.NoObf;
 using System.Linq;
+using Vintagestory;
+using Google.Protobuf.WellKnownTypes;
 
 
 
@@ -150,7 +152,11 @@ namespace Starvation
             { "startfire", 3 },
             { "shieldBlock", 10 },
             { "chiselready", 1.5 },
-            { "chiselhit", 3 }
+            { "chiselhit", 3 },
+            { "combatoverhaul-spear-idle", 2.3 },
+            {"combatoverhaul-spear-ready", 2.3 },
+            {"combatoverhaul-falx-slash", 1.95 }
+
         };
 
 
@@ -387,10 +393,15 @@ namespace Starvation
             double maxMETs = 1;
             double value = 1;
             // list of all active animations
+
             List<string> keyList = new List<string>(entity.AnimManager.ActiveAnimationsByAnimCode.Keys);
 
-            foreach (string animName in keyList)
+            foreach (string aName in keyList)
             {
+                // Potential Optimisation:
+                // Making second Dict with -fp may make it a bit faster, but when it occurs every 500ms I don't think it's a big deal
+                var animName = aName.Replace("-fp", ""); 
+
                 METsByActivity.TryGetValue(animName, out value);
                 maxMETs = Math.Max(maxMETs, value);
             }


### PR DESCRIPTION
Hi, other than giving it support for 1.20 I decided to do some more improvements

Basically only 2 anims out of ~20-30 would work in first person view, that's why I decided to easily fix it (just one line of code)
Also, added support for Combat Overhaul mod (spears, couldn't detect bow anim)

I am also planning in future to make some mechanism for detecting when blocks are destroyed, because it should additionally consume energy, using 1600 Kcal per day seems crazy, IRL I am using 2200 Kcal while sitting a lot in front of PC and doing sport 3 times a week, definitly when you're mining stone your needs should go to 2500-4000 kcal

I hope that you will agree to merge my changes to your mod, if no I'll anyway keep develop the fork, I would also love to talk to you about future of this mod, it seems abounded and I'd love to take care of it even more